### PR TITLE
Add missing config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 dist/
 frontend/node_modules/
 backend/venv/
+
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ This project contains a simple Flask backend and React frontend for an e-commerc
 - `/chat` endpoint streams responses from the model.
 - Basic in-memory usage tracking and token cap (2000 tokens per session).
 
-Run with:
+Install dependencies and run with:
 ```bash
+pip install -r backend/requirements.txt
 python backend/app.py
 ```
 
 ## Frontend
 - Located in `frontend/` using Vite + React.
 - `npm install` then `npm run dev` to start the dev server.
-- Proxy is configured to forward API calls to `localhost:5000`.
+- Proxy rules are defined in `frontend/vite.config.js` so API calls reach `localhost:5000`.
 
 Chat history and settings are kept in session storage.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-Cors
+openai

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/chat': 'http://localhost:5000',
+      '/usage': 'http://localhost:5000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- ignore `__pycache__/`
- document backend dependency installation in README
- add backend `requirements.txt`
- configure frontend Vite proxy

## Testing
- `python -m py_compile backend/app.py`
- `node -e "require('./frontend/vite.config.js'); console.log('ok');"` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68759ad6023883328b0e4b8c55ff6581