### PR TITLE
Setup Vite frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/index.js"></script>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,14 +4,15 @@
   "private": true,
   "proxy": "http://localhost:5000",
   "scripts": {
-    "dev": "vite",
+    "start": "vite",
     "build": "vite build",
+    "dev": "vite",
     "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "^5.0.1"
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
-import './styles.css';
-
-createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- configure Vite scripts and dependencies in frontend
- rename entry point to `main.jsx`
- update `index.html` to use the new entry point

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687661f743cc8332bf2d5e84d86691fd