### PR TITLE
Remove API key from frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,14 +31,12 @@ export default function App() {
 
     const botPlaceholder = { sender: 'bot', text: '', time: new Date().toLocaleTimeString() };
     setMessages(prev => [...prev, botPlaceholder]);
-    const apiKey = sessionStorage.getItem('apiKey') || '';
 
     try {
       const response = await fetch('/chat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-openrouter-key': apiKey,
         },
         body: JSON.stringify({ message: userMsg.text }),
       });

--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -2,11 +2,9 @@ import React, { useState } from 'react';
 
 export default function Settings({ onClose }) {
   const [botName, setBotName] = useState(sessionStorage.getItem('botName') || 'SEEP');
-  const [apiKey, setApiKey] = useState(sessionStorage.getItem('apiKey') || '');
 
   const save = () => {
     sessionStorage.setItem('botName', botName);
-    sessionStorage.setItem('apiKey', apiKey);
     onClose();
   };
 
@@ -17,10 +15,6 @@ export default function Settings({ onClose }) {
         <label>
           Bot name
           <input value={botName} onChange={e => setBotName(e.target.value)} />
-        </label>
-        <label>
-          OpenRouter API key
-          <input value={apiKey} onChange={e => setApiKey(e.target.value)} />
         </label>
         <label>
           Model


### PR DESCRIPTION
## Summary
- rely on backend `.env` for OpenRouter API key
- simplify settings modal

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c374973c8332abef5a0c6804372d