### PR TITLE
Add dashboard onboarding and new analytics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-9VoXf58kEsttWm7VxWbJEHZi6HlXP1ZUAE1V2uxsjjXNMTvEihQ/HVbUaz2YsmiVjCwXTlzAIXazhbug+DUZkg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <title>SEEP Chat</title>
 </head>
 <body>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import SetupModal from './SetupModal';
 
 export default function Dashboard() {
   const [usage, setUsage] = useState(null);
   const [error, setError] = useState(null);
+  const [showSetup, setShowSetup] = useState(!localStorage.getItem('configSet'));
 
   useEffect(() => {
     fetch('/usage')
@@ -17,6 +19,10 @@ export default function Dashboard() {
     'Set up a welcome greeting for new visitors',
   ];
 
+  const clickSuggestion = async () => {
+    await fetch('/conversion', { method: 'POST' });
+  };
+
   if (error) {
     return <div className="dashboard">{error}</div>;
   }
@@ -25,11 +31,15 @@ export default function Dashboard() {
     return <div className="dashboard">Loading...</div>;
   }
 
-  const usageValues = Object.values(usage);
-  const totalChats = usageValues.reduce((sum, u) => sum + u.requests, 0);
-  const monthlyMessages = usageValues.reduce((sum, u) => sum + u.tokens, 0);
-  const avgMessages = (monthlyMessages / Math.max(totalChats, 1)).toFixed(2);
-  const display = { totalChats, monthlyMessages, avgMessages, plan: 'Free Tier' };
+  const display = {
+    totalChats: usage.totalChats,
+    monthlyMessages: usage.monthlyMessages,
+    avgMessages: usage.avgMessages.toFixed ? usage.avgMessages.toFixed(2) : usage.avgMessages,
+    plan: usage.plan,
+    uniqueVisitors: usage.uniqueVisitors,
+    successRate: (usage.successRate * 100).toFixed(1),
+    conversions: usage.conversions,
+  };
 
   return (
     <div className="dashboard">
@@ -37,16 +47,34 @@ export default function Dashboard() {
         <h2 className="section-title">Usage Analytics</h2>
         <div className="stats-grid">
           <div className="card">
+            <i className="fa-solid fa-comments"></i>
             <p className="stat-num">{display.totalChats}</p>
             <p className="stat-label">Total chats</p>
           </div>
           <div className="card">
+            <i className="fa-solid fa-message"></i>
             <p className="stat-num">{display.monthlyMessages.toLocaleString()}</p>
             <p className="stat-label">Monthly messages</p>
           </div>
           <div className="card">
+            <i className="fa-solid fa-chart-line"></i>
             <p className="stat-num">{display.avgMessages}</p>
             <p className="stat-label">Avg. messages/chat</p>
+          </div>
+          <div className="card">
+            <i className="fa-solid fa-user"></i>
+            <p className="stat-num">{display.uniqueVisitors}</p>
+            <p className="stat-label">Visitors</p>
+          </div>
+          <div className="card">
+            <i className="fa-solid fa-circle-check"></i>
+            <p className="stat-num">{display.successRate}%</p>
+            <p className="stat-label">Success rate</p>
+          </div>
+          <div className="card">
+            <i className="fa-solid fa-bolt"></i>
+            <p className="stat-num">{display.conversions}</p>
+            <p className="stat-label">Conversions</p>
           </div>
           <div className="card">
             <p className="stat-num">{display.plan}</p>
@@ -59,12 +87,13 @@ export default function Dashboard() {
         <h2 className="section-title">Smart Suggestions</h2>
         <div className="suggestions-list">
           {suggestions.map((text, i) => (
-            <div key={i} className="card suggestion-card">
+            <div key={i} className="card suggestion-card" onClick={clickSuggestion}>
               {text}
             </div>
           ))}
         </div>
       </section>
+      {showSetup && <SetupModal onClose={() => setShowSetup(false)} />}
     </div>
   );
 }

--- a/frontend/src/SetupModal.jsx
+++ b/frontend/src/SetupModal.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+
+export default function SetupModal({ onClose }) {
+  const [welcome, setWelcome] = useState('');
+  const [tone, setTone] = useState('Friendly');
+  const [business, setBusiness] = useState('');
+
+  useEffect(() => {
+    const domain = window.location.hostname.split('.')[0];
+    setBusiness(domain);
+  }, []);
+
+  const save = async () => {
+    await fetch('/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ welcomeMessage: welcome, tone, businessName: business })
+    });
+    localStorage.setItem('configSet', 'true');
+    onClose();
+  };
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h2>Store Setup</h2>
+        <label>
+          Welcome message
+          <input value={welcome} onChange={e => setWelcome(e.target.value)} />
+        </label>
+        <label>
+          AI tone
+          <select value={tone} onChange={e => setTone(e.target.value)}>
+            <option value="Friendly">Friendly</option>
+            <option value="Formal">Formal</option>
+            <option value="Witty">Witty</option>
+          </select>
+        </label>
+        <label>
+          Business name
+          <input value={business} onChange={e => setBusiness(e.target.value)} />
+        </label>
+        <button onClick={save}>Save</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -169,6 +169,12 @@ textarea {
   font-weight: bold;
 }
 
+.card i {
+  font-size: 1.2rem;
+  margin-bottom: 5px;
+  color: #6366f1;
+}
+
 .suggestions-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- create setup modal for first dashboard visit
- track usage stats server-side
- expose `/config` and `/conversion` endpoints
- show extra analytics cards with FontAwesome icons
- style icons in dashboard cards

## Testing
- `python -m py_compile backend/app.py`
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a3c1506a883329c4f8300e110b21d