### PR TITLE
Add iframe embed and per-bot welcome messages

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -1,0 +1,42 @@
+(function(){
+  var script = document.currentScript || (function(){var s=document.getElementsByTagName('script');return s[s.length-1];})();
+  var url = new URL(script.src);
+  var host = url.origin;
+  var bot = url.searchParams.get('bot_name') || '';
+  var iframe = document.createElement('iframe');
+  iframe.src = host + '/chat?bot_name=' + encodeURIComponent(bot);
+  Object.assign(iframe.style, {
+    position: 'fixed',
+    bottom: '80px',
+    right: '20px',
+    width: '350px',
+    height: '500px',
+    border: 'none',
+    borderRadius: '8px',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+    display: 'none',
+    zIndex: '2147483647'
+  });
+  var bubble = document.createElement('div');
+  bubble.textContent = 'Chat';
+  Object.assign(bubble.style, {
+    position: 'fixed',
+    bottom: '20px',
+    right: '20px',
+    width: '60px',
+    height: '60px',
+    borderRadius: '30px',
+    background: '#6366f1',
+    color: '#fff',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    zIndex: '2147483647'
+  });
+  bubble.onclick = function(){
+    iframe.style.display = iframe.style.display === 'none' ? 'block' : 'none';
+  };
+  document.body.appendChild(iframe);
+  document.body.appendChild(bubble);
+})();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,8 @@ function Message({ sender, text, time }) {
 }
 
 export default function App() {
+  const params = new URLSearchParams(window.location.search);
+  const botName = params.get('bot_name') || localStorage.getItem('botName') || 'SEEP';
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -21,6 +23,16 @@ export default function App() {
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, loading]);
+
+  useEffect(() => {
+    fetch(`/bot/${botName}`)
+      .then(res => res.json())
+      .then(data => {
+        if (data.welcomeMessage) {
+          setMessages([{ sender: 'bot', text: data.welcomeMessage, time: new Date().toLocaleTimeString() }]);
+        }
+      });
+  }, [botName]);
 
   const sendMessage = async () => {
     if (!input.trim()) return;
@@ -76,13 +88,13 @@ export default function App() {
   return (
     <div className="container">
       <header>
-        <h1>{localStorage.getItem('botName') || 'SEEP'} Assistant</h1>
+        <h1>{botName} Assistant</h1>
         <button onClick={() => setShowSettings(true)}>Settings</button>
         <Link to="/dashboard"><button>Dashboard</button></Link>
       </header>
       <div className="chat">
         {messages.map((m, i) => <Message key={i} {...m} />)}
-        {loading && <div className="typing">{(localStorage.getItem('botName') || 'SEEP')} is typing...</div>}
+        {loading && <div className="typing">{botName} is typing...</div>}
         <div ref={bottomRef} />
       </div>
       <div className="input">

--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -1,12 +1,24 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function Settings({ onClose }) {
   const [botName, setBotName] = useState(localStorage.getItem('botName') || 'SEEP');
   const [model, setModel] = useState(localStorage.getItem('model') || 'deepseek/deepseek-chat-v3-0324:free');
+  const [welcome, setWelcome] = useState('');
 
-  const save = () => {
+  useEffect(() => {
+    fetch(`/bot/${botName}`)
+      .then(res => res.json())
+      .then(data => setWelcome(data.welcomeMessage || ''));
+  }, [botName]);
+
+  const save = async () => {
     localStorage.setItem('botName', botName);
     localStorage.setItem('model', model);
+    await fetch(`/bot/${botName}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ welcomeMessage: welcome })
+    });
     onClose();
   };
 
@@ -17,6 +29,10 @@ export default function Settings({ onClose }) {
         <label>
           Bot name
           <input value={botName} onChange={e => setBotName(e.target.value)} />
+        </label>
+        <label>
+          Welcome message
+          <input value={welcome} onChange={e => setWelcome(e.target.value)} />
         </label>
         <label>
           Model


### PR DESCRIPTION
## Summary
- add a simple `embed.js` that injects an iframe chat widget
- support SQLite storage of per-bot welcome messages in backend
- expose `/bot/<bot_name>` API to read and write welcome messages
- show custom welcome message on new chat sessions
- allow editing welcome message from Settings panel

## Testing
- `python -m py_compile backend/app.py`
- `pip install -r backend/requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687a4307a6188332b13d1f4310e97de7