### PR TITLE
Add configurable chat widget endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 import os
 import traceback
 from collections import defaultdict
-from flask import Flask, request, jsonify, Response, stream_with_context
+from flask import Flask, request, jsonify, Response, stream_with_context, send_from_directory
 import sqlite3
 from flask_cors import CORS
 import openai
@@ -323,23 +323,20 @@ def bestsellers():
         return jsonify({"products": []})
 
 
+@app.route("/merchant/config/<merchant_id>")
+def merchant_config(merchant_id: str):
+    """Return basic configuration for a merchant."""
+    return jsonify({"welcomeMessage": get_welcome(merchant_id)})
+
+
 @app.route("/widget/seep-widget.js")
 def widget_script():
     """Serve the embeddable chat widget script."""
-    script = (
-        "(function(){var s=document.currentScript,d=new URL(s.src),h=d.origin,"
-        "b=document.createElement('div'),i=document.createElement('iframe');"
-        "Object.assign(b.style,{position:'fixed',bottom:'20px',right:'20px',"
-        "width:'60px',height:'60px',borderRadius:'30px',background:'#3b82f6',"
-        "color:'#fff',display:'flex',alignItems:'center',justifyContent:'center',"
-        "cursor:'pointer',boxShadow:'0 2px 6px rgba(0,0,0,.3)',zIndex:99999});"
-        "b.innerHTML='Chat';Object.assign(i.style,{position:'fixed',bottom:'90px',"
-        "right:'20px',width:'350px',height:'500px',borderRadius:'8px',border:'none',"
-        "boxShadow:'0 2px 8px rgba(0,0,0,.2)',display:'none',zIndex:99999});"
-        "i.src=h+'/chat?merchant_id=test-merchant';b.onclick=function(){i.style.display=i.style.display==='none'?'block':'none'};"
-        "document.body.appendChild(i);document.body.appendChild(b);})();"
+    return send_from_directory(
+        os.path.join(os.path.dirname(__file__), "static"),
+        "seep-widget.js",
+        mimetype="application/javascript",
     )
-    return Response(script, mimetype="application/javascript")
 
 
 if __name__ == "__main__":

--- a/backend/static/seep-widget.js
+++ b/backend/static/seep-widget.js
@@ -1,0 +1,27 @@
+(function(){
+var s=document.currentScript;
+var mid=s.getAttribute('data-merchant-id')||'test-merchant';
+var host=new URL(s.src).origin;
+function css(t){var e=document.createElement('style');e.textContent=t;document.head.appendChild(e);}
+function init(c){
+css('#seep-bubble{position:fixed;bottom:20px;right:20px;width:60px;height:60px;border-radius:30px;background:#3b82f6;color:#fff;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,.3);z-index:2147483647}#seep-container{position:fixed;bottom:90px;right:20px;width:320px;max-width:90vw;height:450px;max-height:70vh;background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.2);display:none;flex-direction:column;overflow:hidden;z-index:2147483647}#seep-header{background:#3b82f6;color:#fff;padding:10px;font-size:16px}#seep-messages{flex:1;overflow-y:auto;padding:10px;font-size:14px}#seep-input{display:flex;border-top:1px solid #eee}#seep-input textarea{flex:1;padding:8px;border:none;resize:none;font-size:14px}#seep-input button{background:#3b82f6;color:#fff;border:none;padding:0 12px;cursor:pointer}.seep-msg{margin-bottom:8px}.seep-msg.bot{background:#f1f5ff;padding:6px;border-radius:4px}.seep-msg.user{text-align:right}');
+var b=document.createElement('div');
+b.id='seep-bubble';
+b.innerHTML='Chat';
+var f=document.createElement('div');
+f.id='seep-container';
+f.innerHTML='<div id="seep-header">Chat</div><div id="seep-messages"></div><div id="seep-input"><textarea rows="1"></textarea><button>Send</button></div>';
+b.onclick=function(){f.style.display=f.style.display==='flex'?'none':'flex';};
+document.body.appendChild(b);
+document.body.appendChild(f);
+var m=f.querySelector('#seep-messages');
+function add(t,s){var d=document.createElement('div');d.className='seep-msg '+s;d.textContent=t;m.appendChild(d);m.scrollTop=m.scrollHeight;}
+if(c&&c.welcomeMessage)add(c.welcomeMessage,'bot');
+var ta=f.querySelector('textarea');
+var btn=f.querySelector('button');
+function send(){var text=ta.value.trim();if(!text)return;add(text,'user');ta.value='';fetch(host+'/chat',{method:'POST',headers:{"Content-Type":"application/json","x-merchant-id":mid},body:JSON.stringify({message:text})}).then(function(r){if(!r.ok)throw new Error();return r.body.getReader();}).then(function(reader){var dec=new TextDecoder();var bot='';function read(){reader.read().then(function(res){if(res.done)return;bot+=dec.decode(res.value,{stream:!0});if(m.lastChild.className.indexOf('bot')>-1){m.lastChild.textContent=bot;}else{add(bot,'bot');}m.scrollTop=m.scrollHeight;read();});}read();}).catch(function(){add('Error','bot');});}
+btn.onclick=send;
+ta.addEventListener('keydown',function(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send();}});
+}
+fetch(host+'/merchant/config/'+encodeURIComponent(mid)).then(function(r){return r.json();}).then(init).catch(function(){init({});});
+})();


### PR DESCRIPTION
## Summary
- serve the widget JS file from Flask static directory
- expose `/merchant/config/<merchant_id>` for fetching widget config
- include minified client script for embedding on any website

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687aa5d30d848332872ee7d560981166