### PR TITLE
Fix Render host binding

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -353,4 +353,4 @@ def widget_script():
 
 
 if __name__ == "__main__":
-    app.run(port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- make Flask run on `0.0.0.0` so that the backend binds to all network
  interfaces for Render

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab60321f883329c8cba6ab3e16bcc