### PR TITLE
Add backend root route

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,6 +19,11 @@ app = Flask(__name__)
 # Allow embedding from any domain
 CORS(app, resources={r"/*": {"origins": "*"}})
 
+@app.route("/")
+def index():
+    """Simple health check for the API."""
+    return "<h1>SEEP Global API is Live</h1>"
+
 DB_PATH = os.path.join(os.path.dirname(__file__), 'bots.db')
 
 


### PR DESCRIPTION
## Summary
- respond on `/` with an HTML welcome message for live checks

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab76d094c8332b1a11b4c6d812f90