### PR TITLE
Improve embed widget behavior

### DIFF
--- a/backend/static/seep-widget.js
+++ b/backend/static/seep-widget.js
@@ -15,6 +15,16 @@
   }
   var config={};
   var unhelp=0;var pending=null;var m,ta,hint;
+  function timeGreeting(){var h=new Date().getHours();if(h<12)return 'Good morning';if(h<18)return 'Good afternoon';return 'Good evening';}
+  function addMsg(text,type){var d=document.createElement('div');d.className='seep-msg '+type;d.textContent=text;m.appendChild(d);m.scrollTop=m.scrollHeight;return d;}
+  function handleCommand(t){var l=t.toLowerCase();
+    if(/track order/.test(l)){addMsg('Please enter your tracking number or contact support.', 'bot');return true;}
+    if(/view cart/.test(l) && config.cart_url){addMsg(config.cart_url,'bot');return true;}
+    if(/browse products/.test(l) && Array.isArray(config.popular_links)){
+      var links=config.popular_links;var arr=[];for(var i=0;i<links.length;i++){var it=links[i];if(it.url&&it.text)arr.push(it);}showButtons(arr);return arr.length>0;}
+    if(/speak to agent/.test(l) && config.support_email){addMsg('Connecting you to support at '+config.support_email,'bot');return true;}
+    return false;
+  }
 
   function showButtons(arr){if(!arr||!arr.length)return;var d=document.createElement('div');d.className='seep-msg bot';arr.forEach(function(b){d.appendChild(btn(b.text,b.url));});m.appendChild(d);m.scrollTop=m.scrollHeight;}
 
@@ -31,15 +41,15 @@
   var botDiv;
   function init(c){
     config=c||{};
-    css('#seep-bubble{position:fixed;bottom:20px;right:20px;width:60px;height:60px;border-radius:30px;background:#3b82f6;color:#fff;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,.3);z-index:2147483647}#seep-container{position:fixed;bottom:90px;right:20px;width:320px;max-width:90vw;height:450px;max-height:70vh;background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.2);display:none;flex-direction:column;overflow:hidden;z-index:2147483647}#seep-header{background:#3b82f6;color:#fff;padding:10px;font-size:16px}#seep-messages{flex:1;overflow-y:auto;padding:10px;font-size:14px}#seep-input{display:flex;border-top:1px solid #eee}#seep-input textarea{flex:1;padding:8px;border:none;resize:none;font-size:14px}#seep-input button{background:#3b82f6;color:#fff;border:none;padding:0 12px;cursor:pointer}.seep-msg{margin-bottom:8px}.seep-msg.bot{background:#f1f5ff;padding:6px;border-radius:4px}.seep-msg.user{text-align:right}.seep-btn{display:inline-block;margin:4px 4px 0 0;padding:6px 10px;background:#3b82f6;color:#fff;border-radius:4px;text-decoration:none;cursor:pointer}.seep-btn:hover{opacity:.8}#seep-hint{font-size:12px;color:#666;padding:4px;display:none}');
+    css('#seep-bubble{position:fixed;bottom:20px;right:20px;width:60px;height:60px;border-radius:30px;background:#3b82f6;color:#fff;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,.3);z-index:2147483647}#seep-container{position:fixed;bottom:90px;right:20px;width:320px;max-width:90vw;height:450px;max-height:70vh;background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.2);display:none;flex-direction:column;overflow:hidden;z-index:2147483647}#seep-header{background:#3b82f6;color:#fff;padding:10px;font-size:16px}#seep-messages{flex:1;overflow-y:auto;padding:10px;font-size:14px}#seep-input{display:flex;border-top:1px solid #eee}#seep-input textarea{flex:1;padding:8px;border:none;resize:none;font-size:14px}#seep-input button{background:#3b82f6;color:#fff;border:none;padding:0 12px;cursor:pointer}.seep-msg{margin-bottom:8px;padding:8px 12px;border-radius:16px;max-width:80%;line-height:1.4}.seep-msg.bot{background:#f5f7fb;color:#111}.seep-msg.user{background:#3b82f6;color:#fff;margin-left:auto}.seep-btn{display:inline-block;margin:4px 4px 0 0;padding:6px 10px;background:#3b82f6;color:#fff;border-radius:4px;text-decoration:none;cursor:pointer}.seep-btn:hover{opacity:.8}#seep-hint{font-size:12px;color:#666;padding:4px;display:none}');
     var b=document.createElement('div');b.id='seep-bubble';b.innerHTML='Chat';
     var f=document.createElement('div');f.id='seep-container';
     f.innerHTML='<div id="seep-header">Chat</div><div id="seep-messages"></div><div id="seep-input"><textarea rows="1"></textarea><button>Send</button></div><div id="seep-hint">Try asking about shipping, returns, or order status.</div>';
     b.onclick=function(){f.style.display=f.style.display==='flex'?'none':'flex';};
     document.body.appendChild(b);document.body.appendChild(f);
     m=f.querySelector('#seep-messages');ta=f.querySelector('textarea');var btnEl=f.querySelector('button');hint=f.querySelector('#seep-hint');
-    if(c&&c.welcomeMessage) {var d=document.createElement('div');d.className='seep-msg bot';d.textContent=c.welcomeMessage;m.appendChild(d);}
-    function send(){var text=ta.value.trim();if(!text)return;var d=document.createElement('div');d.className='seep-msg user';d.textContent=text;m.appendChild(d);m.scrollTop=m.scrollHeight;pending=smartLinks(text);ta.value='';
+    var greet=timeGreeting();var g=c.greeting||c.welcomeMessage;addMsg(greet+(g?'! '+g:'!'),'bot');
+    function send(){var text=ta.value.trim();if(!text)return;addMsg(text,'user');m.scrollTop=m.scrollHeight;ta.value='';if(handleCommand(text)) return;pending=smartLinks(text);
       fetch(host+'/chat',{method:'POST',headers:{"Content-Type":"application/json","x-merchant-id":mid},body:JSON.stringify({message:text})}).then(function(r){if(!r.ok)throw new Error();return r.body.getReader();}).then(function(reader){var dec=new TextDecoder();var bot='';botDiv=null;function read(){reader.read().then(function(res){if(res.done){if(botDiv)handleBot(bot);return;}bot+=dec.decode(res.value,{stream:true});if(botDiv)botDiv.textContent=bot;else{botDiv=document.createElement('div');botDiv.className='seep-msg bot';botDiv.textContent=bot;m.appendChild(botDiv);}m.scrollTop=m.scrollHeight;read();});}read();}).catch(function(){var er=document.createElement('div');er.className='seep-msg bot';er.textContent='Error';m.appendChild(er);});}
     btnEl.onclick=send;
     ta.addEventListener('keydown',function(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send();}});


### PR DESCRIPTION
## Summary
- tweak the embeddable widget to read new merchant configuration
- greet visitors with a time-based message
- intercept smart commands (track order/view cart/browse products/speak to agent)
- modernize chat bubble styles

## Testing
- `python -m py_compile backend/app.py`
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b8a8387dc83328e935855a786834b