### PR TITLE
Enhance chat widget

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -362,6 +362,21 @@ def analytics():
     return jsonify({"status": "ok"})
 
 
+@app.route("/log", methods=["GET", "POST"])
+def log_event():
+    """Simple event logger used by the widget."""
+    event = request.args.get("event")
+    if not event:
+        return jsonify({"error": "event required"}), 400
+    analytics_events[event].append(
+        {
+            "timestamp": datetime.utcnow().isoformat(),
+            "ip": request.remote_addr,
+        }
+    )
+    return jsonify({"status": "ok"})
+
+
 @app.route("/merchant/config/<merchant_id>")
 def merchant_config(merchant_id: str):
     """Return basic configuration for a merchant."""
@@ -378,6 +393,16 @@ def widget_script():
         os.path.join(os.path.dirname(__file__), "static"),
         "seep-widget.js",
         mimetype="application/javascript",
+    )
+
+
+@app.route("/widget/seep-style.css")
+def widget_style():
+    """Serve the embeddable chat widget stylesheet."""
+    return send_from_directory(
+        os.path.join(os.path.dirname(__file__), "static"),
+        "seep-style.css",
+        mimetype="text/css",
     )
 
 

--- a/backend/static/seep-style.css
+++ b/backend/static/seep-style.css
@@ -1,0 +1,182 @@
+:root {
+  --seep-color: #3b82f6;
+}
+
+#seep-bubble {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 60px;
+  height: 60px;
+  border-radius: 30px;
+  background: var(--seep-color);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,.3);
+  z-index: 2147483647;
+}
+
+#seep-container {
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  width: 320px;
+  max-width: 95vw;
+  height: 450px;
+  max-height: 70vh;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.2);
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 2147483647;
+}
+
+@media (max-width: 600px) {
+  #seep-container {
+    width: 80vw;
+    right: 10vw;
+  }
+}
+
+#seep-header {
+  background: var(--seep-color);
+  color: #fff;
+  padding: 10px;
+  font-size: 16px;
+}
+
+#seep-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+  font-size: 14px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+}
+
+#seep-input {
+  display: flex;
+  border-top: 1px solid #eee;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+#seep-input textarea {
+  flex: 1;
+  padding: 8px;
+  border: none;
+  resize: none;
+  font-size: 14px;
+}
+
+#seep-input button {
+  background: var(--seep-color);
+  color: #fff;
+  border: none;
+  padding: 0 12px;
+  cursor: pointer;
+}
+
+#seep-actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid #eee;
+  justify-content: space-around;
+}
+
+#seep-actions a {
+  flex: 1;
+  text-align: center;
+}
+
+.seep-msg {
+  margin-bottom: 8px;
+  padding: 8px 12px;
+  border-radius: 16px;
+  max-width: 80%;
+  line-height: 1.4;
+  box-shadow: 0 1px 3px rgba(0,0,0,.1);
+  opacity: 0;
+  animation: fade-in .3s forwards;
+}
+
+.seep-msg.bot {
+  align-self: flex-start;
+  background: #f5f7fb;
+  color: #111;
+}
+
+.seep-msg.user {
+  align-self: flex-end;
+  background: var(--seep-color);
+  color: #fff;
+}
+
+.seep-btn {
+  display: inline-block;
+  margin: 4px 4px 0 0;
+  padding: 6px 10px;
+  background: var(--seep-color);
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.seep-btn:hover {
+  opacity: .8;
+}
+
+#seep-hint {
+  font-size: 12px;
+  color: #666;
+  padding: 4px;
+  display: none;
+}
+
+.seep-msg.typing {
+  display: flex;
+  gap: 4px;
+}
+
+.seep-msg.typing span {
+  width: 6px;
+  height: 6px;
+  background: #bbb;
+  border-radius: 50%;
+  animation: typing 1s infinite;
+}
+
+#seep-quick {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 4px 0;
+}
+
+.seep-reply {
+  border: none;
+  background: #eee;
+  border-radius: 12px;
+  padding: 4px 8px;
+  margin: 2px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+@keyframes typing {
+  0% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+  100% { transform: translateY(0); }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- add styling file for the widget and serve it from Flask
- load CSS dynamically and support color theming
- log open/message events via new /log endpoint
- add dynamic cart/checkout URLs in extra buttons

## Testing
- `pytest -q`
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687b95d4773c8332a375a9845e35296c