### PR TITLE
Add merchant setup page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 import os
 import traceback
 from collections import defaultdict
-from flask import Flask, request, jsonify, Response, stream_with_context, send_from_directory
+from flask import Flask, request, jsonify, Response, stream_with_context, send_from_directory, render_template
 import sqlite3
 from flask_cors import CORS
 import openai
@@ -384,6 +384,28 @@ def merchant_config(merchant_id: str):
     cfg = {"welcomeMessage": get_welcome(merchant_id)}
     cfg.update(links)
     return jsonify(cfg)
+
+
+@app.route("/merchant/config", methods=["POST"])
+def merchant_config_save():
+    """Save merchant configuration from the onboarding form."""
+    data = request.get_json(force=True) or {}
+    merchant_id = data.get("merchantId")
+    if not merchant_id:
+        return jsonify({"error": "merchantId required"}), 400
+    merchant_configs[merchant_id] = {
+        "cartUrl": data.get("cartUrl", ""),
+        "checkoutUrl": data.get("checkoutUrl", ""),
+        "contactUrl": data.get("contactUrl", ""),
+    }
+    save_welcome(merchant_id, data.get("welcomeGreeting", ""))
+    return jsonify({"status": "ok"})
+
+
+@app.route("/setup-widget")
+def setup_widget():
+    """Render merchant onboarding form."""
+    return render_template("setup_widget.html")
 
 
 @app.route("/widget/seep-widget.js")

--- a/backend/templates/setup_widget.html
+++ b/backend/templates/setup_widget.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Setup Widget</title>
+  <style>
+    body{font-family:Arial,Helvetica,sans-serif;background:#fff;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;padding:20px;}
+    form{max-width:400px;width:100%;}
+    label{font-weight:bold;display:block;margin-top:12px;}
+    input{width:100%;padding:8px;margin-top:4px;box-sizing:border-box;}
+    button{margin-top:20px;padding:10px;background:#3b82f6;color:#fff;border:none;width:100%;cursor:pointer;border-radius:4px;}
+    #success{margin-top:20px;padding:10px;background:#e6ffed;border:1px solid #b2f5bf;display:none;word-break:break-all;}
+  </style>
+</head>
+<body>
+  <form id="setup-form">
+    <label>Merchant ID<input type="text" name="merchantId" required></label>
+    <label>Welcome Greeting<input type="text" name="welcomeGreeting" required></label>
+    <label>Cart URL<input type="url" name="cartUrl" required></label>
+    <label>Checkout URL<input type="url" name="checkoutUrl" required></label>
+    <label>Contact URL<input type="url" name="contactUrl" required></label>
+    <button type="submit">Save</button>
+    <div id="success"></div>
+  </form>
+<script>
+  document.getElementById('setup-form').addEventListener('submit', async function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    const data = Object.fromEntries(fd.entries());
+    const res = await fetch('/merchant/config', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify(data)
+    });
+    if(res.ok){
+      const code = `<script src=\"https://seep-global.onrender.com/widget/seep-widget.js\" data-merchant-id=\"${data.merchantId}\"><\/script>`;
+      const box = document.getElementById('success');
+      box.textContent = code;
+      box.style.display = 'block';
+    }
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a Jinja template for merchant onboarding form
- add `/setup-widget` route to display the template
- implement POST `/merchant/config` for saving settings

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687b9b8b30c8833282fb484d60f71644