### PR TITLE
Add merchant dashboard endpoints

### DIFF
--- a/backend/templates/dashboard.html
+++ b/backend/templates/dashboard.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Merchant Dashboard</title>
+</head>
+<body>
+  <h1>Merchant Dashboard</h1>
+  <p>This is a placeholder dashboard page.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- log chat messages and merchant usage in memory
- add `/merchant/<merchant_id>/usage` endpoint
- add `/merchant/<merchant_id>/logs` endpoint
- add `/merchant/<merchant_id>/suggestions` endpoint with dummy tips
- serve dashboard HTML from `/merchant/dashboard`

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687b9f734d7883328ee727e0b0cdde37