### PR TITLE
Add persistent navbar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import ChatApp from './ChatApp';
 import Dashboard from './Dashboard';
+import Navbar from './Navbar';
 
 export default function App() {
   return (
     <BrowserRouter>
+      <Navbar />
       <Routes>
         <Route path="/" element={<ChatApp />} />
         <Route path="/dashboard" element={<Dashboard />} />

--- a/frontend/src/ChatApp.jsx
+++ b/frontend/src/ChatApp.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Settings from './Settings';
-import { Link } from 'react-router-dom';
 
 function Message({ sender, text, time }) {
   return (
@@ -92,7 +91,6 @@ export default function ChatApp() {
       <header>
         <h1>{botName} Assistant</h1>
         <button onClick={() => setShowSettings(true)}>Settings</button>
-        <Link to="/dashboard"><button>Dashboard</button></Link>
       </header>
       <div className="chat">
         {messages.map((m, i) => <Message key={i} {...m} />)}

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 
 export default function Dashboard() {
   const [merchantId, setMerchantId] = useState('demo');
@@ -45,9 +44,6 @@ export default function Dashboard() {
     <div className="p-4 max-w-3xl mx-auto space-y-6">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Merchant Dashboard</h1>
-        <Link to="/">
-          <button className="bg-indigo-600 text-white px-3 py-1 rounded">Back to Chat</button>
-        </Link>
       </div>
 
       <div className="flex flex-wrap items-end gap-2">

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import './styles.css';
+
+export default function Navbar() {
+  return (
+    <nav className="navbar">
+      <div className="nav-links">
+        <NavLink
+          end
+          to="/"
+          className={({ isActive }) =>
+            isActive ? 'nav-link active' : 'nav-link'
+          }
+        >
+          Chat Assistant
+        </NavLink>
+        <NavLink
+          to="/dashboard"
+          className={({ isActive }) =>
+            isActive ? 'nav-link active' : 'nav-link'
+          }
+        >
+          Merchant Dashboard
+        </NavLink>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -7,6 +7,38 @@ body {
   justify-content: center;
   align-items: flex-start;
   min-height: 100vh;
+  padding-top: 60px; /* space for fixed navbar */
+}
+
+/* Navigation Bar */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  z-index: 50;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  color: #4b5563;
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  font-weight: 500;
+}
+
+.nav-link.active {
+  font-weight: 700;
+  border-bottom: 2px solid #6366f1;
 }
 .container {
   width: 100%;
@@ -14,7 +46,7 @@ body {
   margin: 20px;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 40px);
+  height: calc(100vh - 40px - 60px);
   background: #ffffff;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Summary
- create `Navbar` component with links for Chat Assistant and Merchant Dashboard
- mount `Navbar` in `App.jsx`
- adjust `ChatApp` and `Dashboard` headers to remove now-redundant links
- style navbar and page layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bda188c00833296cbb4ffaf8ceba4