### PR TITLE
Update routing with Navbar and fallback

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import ChatApp from './ChatApp';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import Chat from './Chat';
 import Dashboard from './Dashboard';
 import Navbar from './Navbar';
 
@@ -9,8 +9,9 @@ export default function App() {
     <BrowserRouter>
       <Navbar />
       <Routes>
-        <Route path="/" element={<ChatApp />} />
+        <Route path="/" element={<Chat />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/Chat.jsx
+++ b/frontend/src/Chat.jsx
@@ -1,0 +1,2 @@
+import ChatApp from './ChatApp';
+export default ChatApp;


### PR DESCRIPTION
## Summary
- add simple `Chat.jsx` wrapper component
- route through `Chat` and redirect invalid URLs
- show navbar across all pages

## Testing
- `npm run build` *(fails: `vite: not found`)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687bdca65b0c8332b0ded1a05ccb765f