### PR TITLE
Fix backend imports for direct execution

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 import requests
 import difflib
 from datetime import datetime
-from .models import Base, engine, SessionLocal, init_db as init_sqlalchemy_db, Merchant
+from models import Base, engine, SessionLocal, init_db as init_sqlalchemy_db, Merchant
 import uuid
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- use absolute imports when loading models in `app.py`

## Testing
- `python -m py_compile backend/app.py backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_687e9544a3d48332b60a6af7b0ec04e8