### PR TITLE
Implement session-based merchant auth

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import uuid
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Text, ForeignKey
 from sqlalchemy.orm import declarative_base, sessionmaker
+from flask_login import UserMixin
 
 DB_PATH = os.path.join(os.path.dirname(__file__), 'bots.db')
 
@@ -17,7 +18,7 @@ def get_db():
     finally:
         db.close()
 
-class Merchant(Base):
+class Merchant(UserMixin, Base):
     __tablename__ = 'merchants'
     id = Column(String, primary_key=True)
     email = Column(String, unique=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 Flask-Cors
+Flask-Login
 openai
 python-dotenv
 requests

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 const API_BASE = 'http://localhost:5000';
 
 export default function Dashboard() {
-  const [merchantId, setMerchantId] = useState('demo');
+  const [merchantId, setMerchantId] = useState('');
   const [usage, setUsage] = useState(null);
   const [logs, setLogs] = useState([]);
   const [tips, setTips] = useState([]);
@@ -16,9 +16,9 @@ export default function Dashboard() {
     setError('');
     try {
       const [uRes, lRes, sRes] = await Promise.all([
-        fetch(`${API_BASE}/merchant/${merchantId}/usage`),
-        fetch(`${API_BASE}/merchant/${merchantId}/logs`),
-        fetch(`${API_BASE}/merchant/${merchantId}/suggestions`)
+        fetch(`${API_BASE}/merchant/usage`),
+        fetch(`${API_BASE}/merchant/logs`),
+        fetch(`${API_BASE}/merchant/suggestions`)
       ]);
 
       if (!uRes.ok || !lRes.ok || !sRes.ok) {
@@ -92,7 +92,7 @@ export default function Dashboard() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${merchantId}_logs.csv`;
+    a.download = `${merchantId || 'merchant'}_logs.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -109,17 +109,11 @@ export default function Dashboard() {
       </div>
 
       <div className="flex flex-wrap items-end gap-2">
-        <input
-          className="border p-2 flex-1 min-w-[150px]"
-          value={merchantId}
-          onChange={e => setMerchantId(e.target.value)}
-          placeholder="Merchant ID"
-        />
         <button
           onClick={fetchData}
           className="bg-indigo-500 text-white px-4 py-2 rounded"
         >
-          Fetch Data
+          Refresh
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- support Flask-Login in backend and add merchant login & registration
- store passwords hashed and create default merchant with password
- protect merchant dashboard APIs with `login_required`
- update dashboard frontend to use new session based API routes

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ebb8e2efc8332a75131ad27ea8b9a