### PR TITLE
Add product awareness settings

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -37,6 +37,10 @@ class Merchant(UserMixin, Base):
     product_endpoint = Column(String)
     product_sync_status = Column(String)
     product_last_synced = Column(DateTime)
+    # New fields for product awareness configuration
+    product_method = Column(String)
+    api_type = Column(String)
+    store_url = Column(String)
 
 class Product(Base):
     __tablename__ = 'products'
@@ -47,6 +51,18 @@ class Product(Base):
     price = Column(String)
     url = Column(String)
     image = Column(String)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+# New table for cached merchant product data
+class MerchantProduct(Base):
+    __tablename__ = 'merchant_products'
+    id = Column(Integer, primary_key=True)
+    merchant_id = Column(String, ForeignKey('merchants.id'))
+    title = Column(String)
+    description = Column(Text)
+    price = Column(String)
+    image_url = Column(String)
+    link = Column(String)
     updated_at = Column(DateTime, default=datetime.utcnow)
 
 class MerchantUsage(Base):


### PR DESCRIPTION
## Summary
- add product awareness columns and MerchantProduct table
- fetch and store product data from HTML or API sources
- expose `/merchant/product-settings/<id>` endpoint
- sync products when chatbot loads
- extend dashboard with a Product Awareness tab

## Testing
- `python -m py_compile backend/*.py`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687ec1ebbc688332b1a20a88d8790de5