### PR TITLE
Add product awareness features

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ To embed the assistant on any page, include the widget script served by the back
 ```
 
 This script automatically fetches the configuration and displays a chat bubble that communicates with the `/chat` endpoint.
+
+## Product Awareness UI
+
+The merchant dashboard now includes a **Product Awareness** tab. From this tab you can either connect your store's API or allow the bot to scan your public site:
+
+1. **API Connection** – Choose Shopify or WooCommerce and enter your API key (and secret for WooCommerce) along with your store URL. Save the settings and click **Refresh Products** to cache product data.
+2. **Structured HTML** – Select "Structured HTML" to let the backend crawl your site starting from the store or cart URL. Product information in schema.org or Open Graph format will be detected automatically.
+
+After syncing, cached products are shown along with sync status and last updated time.

--- a/backend/models.py
+++ b/backend/models.py
@@ -31,6 +31,7 @@ class Merchant(UserMixin, Base):
     checkout_url = Column(String)
     contact_url = Column(String)
     api_key = Column(String, unique=True)
+    api_secret = Column(String)
     store_type = Column(String)
     store_domain = Column(String)
     store_api_key = Column(String)

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -220,6 +220,12 @@ export default function Dashboard() {
                   API Key
                   <input className="border ml-2" value={productSettings.apiKey || ''} onChange={e => setProductSettings(ps => ({...ps, apiKey: e.target.value}))} />
                 </label>
+                {productSettings.apiType === 'woocommerce' && (
+                  <label className="block">
+                    API Secret
+                    <input className="border ml-2" value={productSettings.apiSecret || ''} onChange={e => setProductSettings(ps => ({...ps, apiSecret: e.target.value}))} />
+                  </label>
+                )}
                 <label className="block">
                   Store URL
                   <input className="border ml-2" value={productSettings.storeUrl || ''} onChange={e => setProductSettings(ps => ({...ps, storeUrl: e.target.value}))} />


### PR DESCRIPTION
## Summary
- support WooCommerce API secrets and add new `/products` route
- allow fallback when no products are found
- crawl site from cart or store URL
- expose API secret field in dashboard UI
- document product awareness tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec4d7b0f88332a34086fe038dbbc6