### PR TITLE
Add Shopify sync and smart product suggestions

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -42,6 +42,11 @@ class Merchant(UserMixin, Base):
     product_method = Column(String)
     api_type = Column(String)
     store_url = Column(String)
+    # Shopify specific fields
+    shopify_domain = Column(String)
+    shopify_token = Column(String)
+    # Enable product suggestions feature
+    suggest_products = Column(Integer, default=1)
 
 class Product(Base):
     __tablename__ = 'products'
@@ -50,20 +55,8 @@ class Product(Base):
     title = Column(String)
     description = Column(Text)
     price = Column(String)
-    url = Column(String)
-    image = Column(String)
-    updated_at = Column(DateTime, default=datetime.utcnow)
-
-# New table for cached merchant product data
-class MerchantProduct(Base):
-    __tablename__ = 'merchant_products'
-    id = Column(Integer, primary_key=True)
-    merchant_id = Column(String, ForeignKey('merchants.id'))
-    title = Column(String)
-    description = Column(Text)
-    price = Column(String)
     image_url = Column(String)
-    link = Column(String)
+    product_url = Column(String)
     updated_at = Column(DateTime, default=datetime.utcnow)
 
 class MerchantUsage(Base):

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -216,6 +216,18 @@ export default function Dashboard() {
                     <option value="woocommerce">WooCommerce</option>
                   </select>
                 </label>
+                {productSettings.apiType === 'shopify' && (
+                  <>
+                    <label className="block">
+                      Shopify Store URL
+                      <input className="border ml-2" value={productSettings.shopifyDomain || ''} onChange={e => setProductSettings(ps => ({...ps, shopifyDomain: e.target.value}))} />
+                    </label>
+                    <label className="block">
+                      Storefront Access Token
+                      <input className="border ml-2" value={productSettings.shopifyToken || ''} onChange={e => setProductSettings(ps => ({...ps, shopifyToken: e.target.value}))} />
+                    </label>
+                  </>
+                )}
                 <label className="block">
                   API Key
                   <input className="border ml-2" value={productSettings.apiKey || ''} onChange={e => setProductSettings(ps => ({...ps, apiKey: e.target.value}))} />


### PR DESCRIPTION
## Summary
- add Shopify fields to merchant model
- rework products table and syncing logic
- implement Shopify storefront sync
- provide product suggestions and fallback results in chat
- expose Shopify settings in dashboard UI

## Testing
- `python -m py_compile backend/app.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_687ec9af2e4483329064a68e3b5a1609