### PR TITLE
Add bot customization settings and product sync model

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ The merchant dashboard now includes a **Product Awareness** tab. From this tab y
 2. **Structured HTML** – Select "Structured HTML" to let the backend crawl your site starting from the store or cart URL. Product information in schema.org or Open Graph format will be detected automatically.
 
 After syncing, cached products are shown along with sync status and last updated time.
+
+A new **Customize Bot** tab lets you update the welcome greeting, choose the
+widget colour and toggle product suggestions. Changes are persisted to your
+merchant account and are picked up by the chat widget automatically.
+
+### Updating the database
+
+Schema changes may lead to errors such as `no such column` if an old
+`bots.db` file is present. Simply delete `backend/bots.db` and restart the
+backend to re-create the database with the latest tables.

--- a/backend/models.py
+++ b/backend/models.py
@@ -48,16 +48,16 @@ class Merchant(UserMixin, Base):
     # Enable product suggestions feature
     suggest_products = Column(Integer, default=1)
 
-class Product(Base):
-    __tablename__ = 'products'
+class MerchantProduct(Base):
+    __tablename__ = 'merchant_products'
     id = Column(Integer, primary_key=True)
     merchant_id = Column(String, ForeignKey('merchants.id'))
     title = Column(String)
     description = Column(Text)
     price = Column(String)
     image_url = Column(String)
-    product_url = Column(String)
-    updated_at = Column(DateTime, default=datetime.utcnow)
+    url = Column(String)
+    scraped_at = Column(DateTime, default=datetime.utcnow)
 
 class MerchantUsage(Base):
     __tablename__ = 'merchant_usage'

--- a/frontend/src/ChatApp.jsx
+++ b/frontend/src/ChatApp.jsx
@@ -13,8 +13,7 @@ function Message({ sender, text, time }) {
 }
 
 export default function ChatApp() {
-  const params = new URLSearchParams(window.location.search);
-  const botName = params.get('bot_name') || localStorage.getItem('botName') || 'SEEP';
+  const botName = 'Seep';
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);

--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 const API_BASE = 'http://localhost:5000';
 
 export default function Settings({ onClose }) {
-  const [botName, setBotName] = useState(localStorage.getItem('botName') || 'SEEP');
+  const botName = 'Seep';
   const [model, setModel] = useState(localStorage.getItem('model') || 'deepseek/deepseek-chat-v3-0324:free');
   const [welcome, setWelcome] = useState('');
 
@@ -11,10 +11,9 @@ export default function Settings({ onClose }) {
     fetch(`${API_BASE}/bot/${botName}`)
       .then(res => res.json())
       .then(data => setWelcome(data.welcomeMessage || ''));
-  }, [botName]);
+  }, []);
 
   const save = async () => {
-    localStorage.setItem('botName', botName);
     localStorage.setItem('model', model);
     await fetch(`${API_BASE}/bot/${botName}`, {
       method: 'POST',
@@ -28,10 +27,6 @@ export default function Settings({ onClose }) {
     <div className="modal">
       <div className="modal-content">
         <h2>Settings</h2>
-        <label>
-          Bot name
-          <input value={botName} onChange={e => setBotName(e.target.value)} />
-        </label>
         <label>
           Welcome message
           <input value={welcome} onChange={e => setWelcome(e.target.value)} />


### PR DESCRIPTION
## Summary
- switch products table to `merchant_products` with `MerchantProduct` model
- include merchant color and greeting in configuration
- add `/merchant/bot-settings` endpoint
- improve product context matching in chat
- implement "Customize Bot" UI tab and force bot name to "Seep"
- document database reset procedure

## Testing
- `python -m py_compile backend/app.py backend/models.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ece2b5a9883328d26b60b8bfda74d