### PR TITLE
Add merchant product scraping endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -490,9 +490,13 @@ def chat():
         scored.sort(key=lambda x: x[0], reverse=True)
         top_matches = [p for score, p in scored[:3] if score > 0.2]
 
+    preview_text = ""
     if top_matches:
         product_info = "\n".join(
             f"- {p.title} ({p.price}): {p.url}" for p in top_matches if p.title
+        )
+        preview_text = "\n\nSuggested products:\n" + "\n".join(
+            f"- {p.title} ({p.price}) {p.url}" for p in top_matches if p.title
         )
     else:
         product_info = "\n".join(
@@ -550,6 +554,9 @@ def chat():
                 token = chunk.choices[0].delta.content or ""
                 full += token
                 yield token
+            if preview_text:
+                yield preview_text
+                full += preview_text
             token_count = len(full.split())
             sess["tokens"] += token_count
             merchant_usage[merchant_id]["tokens"] += token_count
@@ -982,6 +989,51 @@ def merchant_bot_settings():
                 "suggestProducts": bool(m.suggest_products) if m else False,
             }
         )
+
+
+@app.route("/merchant/<merchant_id>/scrape-products", methods=["POST"])
+@login_required
+def scrape_products(merchant_id):
+    """Manually scrape product data from the merchant store URL."""
+    if merchant_id != current_user.id:
+        return jsonify({"error": "unauthorized"}), 403
+
+    with SessionLocal() as db:
+        m = db.query(Merchant).get(merchant_id)
+        if not m or not m.store_url:
+            return jsonify({"error": "store_url_missing"}), 400
+
+        try:
+            resp = requests.get(m.store_url, timeout=10)
+            soup = BeautifulSoup(resp.text, "html.parser")
+            items = _extract_products(soup, m.store_url)
+            added = 0
+            for item in items:
+                url = item.get("url")
+                if not url:
+                    continue
+                exists = (
+                    db.query(MerchantProduct)
+                    .filter_by(merchant_id=merchant_id, url=url)
+                    .first()
+                )
+                if exists:
+                    continue
+                db.add(
+                    MerchantProduct(
+                        merchant_id=merchant_id,
+                        title=item.get("title"),
+                        description=item.get("description"),
+                        price=item.get("price"),
+                        image_url=item.get("image"),
+                        url=url,
+                    )
+                )
+                added += 1
+            db.commit()
+            return jsonify({"status": "ok", "count": added})
+        except Exception:
+            return jsonify({"error": "scrape_failed"}), 500
 
 
 @app.route("/merchant/<merchant_id>/products", methods=["GET", "POST"])

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,16 @@
 import os
 from datetime import datetime
 import uuid
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, Text, ForeignKey
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Text,
+    ForeignKey,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import declarative_base, sessionmaker
 from flask_login import UserMixin
 
@@ -50,7 +59,7 @@ class Merchant(UserMixin, Base):
 
 class MerchantProduct(Base):
     __tablename__ = 'merchant_products'
-    id = Column(Integer, primary_key=True)
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     merchant_id = Column(String, ForeignKey('merchants.id'))
     title = Column(String)
     description = Column(Text)
@@ -58,6 +67,10 @@ class MerchantProduct(Base):
     image_url = Column(String)
     url = Column(String)
     scraped_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint('merchant_id', 'url'),
+    )
 
 class MerchantUsage(Base):
     __tablename__ = 'merchant_usage'


### PR DESCRIPTION
## Summary
- add unique UUID-based `merchant_products` table entries
- implement `/merchant/<id>/scrape-products` endpoint to pull product data from store HTML
- append product suggestions to chat responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3595759083328844923c32274a01