### PR TITLE
Add reset_db helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,9 @@ merchant account and are picked up by the chat widget automatically.
 ### Updating the database
 
 Schema changes may lead to errors such as `no such column` if an old
-`bots.db` file is present. Simply delete `backend/bots.db` and restart the
-backend to re-create the database with the latest tables.
+`bots.db` file is present. Run the helper script below to remove the
+database, recreate all tables and seed a `test-merchant` account:
+
+```bash
+python reset_db.py
+```

--- a/reset_db.py
+++ b/reset_db.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import sqlite3
+import uuid
+from werkzeug.security import generate_password_hash
+
+# Ensure we can import modules from the backend folder
+BASE_DIR = os.path.dirname(__file__)
+BACKEND_DIR = os.path.join(BASE_DIR, "backend")
+sys.path.append(BACKEND_DIR)
+
+from models import DB_PATH, init_db, SessionLocal, Merchant
+
+
+def init_sqlite_tables():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS bots (name TEXT PRIMARY KEY, welcome_message TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS faqs (id INTEGER PRIMARY KEY AUTOINCREMENT, question TEXT UNIQUE, answer TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_default_merchant():
+    with SessionLocal() as db:
+        if not db.query(Merchant).filter_by(id="test-merchant").first():
+            m = Merchant(
+                id="test-merchant",
+                email="test@example.com",
+                password_hash=generate_password_hash("password"),
+                api_key=str(uuid.uuid4()),
+                api_secret=str(uuid.uuid4()),
+                greeting="Welcome to Seep!",
+                cart_url="https://store.com/cart",
+                checkout_url="https://store.com/checkout",
+                contact_url="mailto:support@store.com",
+                product_method="html",
+                store_url="store.com",
+                suggest_products=1,
+            )
+            db.add(m)
+            db.commit()
+
+
+def main():
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+    init_db()
+    init_sqlite_tables()
+    add_default_merchant()
+    print(f"Database reset complete. New database at {DB_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add reset_db.py to clean and recreate the database
- update README with instructions for running reset_db.py

## Testing
- `python -m py_compile reset_db.py`
- `python -m py_compile backend/app.py backend/models.py`
- `python reset_db.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_687f45f3e8ac833293a9157b124ddbd6