### PR TITLE
Implement login and error logging

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -118,6 +118,15 @@ class AnalyticsEvent(Base):
     type = Column(String)
     details = Column(Text)
 
+
+class ErrorLog(Base):
+    __tablename__ = 'error_logs'
+    id = Column(Integer, primary_key=True)
+    merchant_id = Column(String, ForeignKey('merchants.id'))
+    message = Column(Text)
+    stack_trace = Column(Text)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
 def init_db():
     Base.metadata.create_all(bind=engine)
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Chat from './Chat';
 import Dashboard from './Dashboard';
+import Login from './Login';
+import Signup from './Signup';
 import Navbar from './Navbar';
 
 // For easier debugging, install React DevTools: https://reactjs.org/link/react-devtools
@@ -12,6 +14,8 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Chat />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -203,6 +203,12 @@ export default function Dashboard() {
               <p className="text-lg font-bold">{usage.tokens}</p>
               <p className="text-sm text-gray-500">Tokens Used</p>
             </div>
+            {usage.limit !== null && (
+              <div className="bg-white p-4 rounded shadow text-center">
+                <p className="text-lg font-bold">{usage.tokens}/{usage.limit}</p>
+                <p className="text-sm text-gray-500">Token Usage</p>
+              </div>
+            )}
             <div className="bg-white p-4 rounded shadow text-center">
               <p className="text-lg font-bold">{usage.avgTokens.toFixed ? usage.avgTokens.toFixed(1) : usage.avgTokens}</p>
               <p className="text-sm text-gray-500">Avg Tokens/Chat</p>
@@ -341,6 +347,9 @@ export default function Dashboard() {
           {alert}
         </div>
       )}
+      <footer className="text-center text-xs text-gray-400 mt-8">
+        <a href="https://docs.seep.ai" target="_blank" rel="noopener noreferrer">SEEP Documentation</a>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+const API_BASE = 'http://localhost:5000';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch(`${API_BASE}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      window.location.href = '/dashboard';
+    } else {
+      const data = await res.json();
+      setError(data.error || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-xl font-semibold mb-4">Login</h1>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      <form onSubmit={submit} className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button type="submit" className="bg-indigo-500 text-white px-4 py-2 rounded w-full">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -23,6 +23,14 @@ export default function Navbar() {
         >
           Merchant Dashboard
         </NavLink>
+        <NavLink
+          to="/login"
+          className={({ isActive }) =>
+            isActive ? 'nav-link active' : 'nav-link'
+          }
+        >
+          Login
+        </NavLink>
       </div>
     </nav>
   );

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+const API_BASE = 'http://localhost:5000';
+
+export default function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch(`${API_BASE}/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      window.location.href = '/dashboard';
+    } else {
+      const data = await res.json();
+      setError(data.error || 'Signup failed');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-xl font-semibold mb-4">Sign Up</h1>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      <form onSubmit={submit} className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button type="submit" className="bg-indigo-500 text-white px-4 py-2 rounded w-full">Create Account</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/signup`, `/login`, and `/logout` routes
- clean asterisk characters from streamed chat output
- enforce token limits via session-based merchant id
- add error logging model and `/errors` endpoints
- show token limits and docs link in dashboard
- provide simple login and signup pages

## Testing
- `python -m py_compile backend/app.py backend/models.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6527f66483328edbe5565ffbecf7