### PR TITLE
Finalize production checks

### DIFF
--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+</head>
+<body>
+  <h1>Merchant Login</h1>
+  <form method="post" action="/login">
+    <label>Email <input type="email" name="email" required></label><br>
+    <label>Password <input type="password" name="password" required></label><br>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -37,7 +37,6 @@ export default function Dashboard() {
       const toJson = async (res) => {
         const text = await res.text();
         if (!res.headers.get('content-type')?.includes('application/json')) {
-          console.warn('Expected JSON but received:', text.slice(0, 100));
           return null;
         }
         return JSON.parse(text);


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to `/login`
- simplify `Dashboard.jsx` by removing console warning
- add basic HTML login form for GET `/login`

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687f92fa43e88332872f121f0aaf1997