### PR TITLE
Implement admin dashboard with broadcasts

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -157,6 +157,14 @@ class ErrorLog(Base):
     stack_trace = Column(Text)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
+
+class Broadcast(Base):
+    """Admin broadcast messages."""
+    __tablename__ = "broadcasts"
+    id = Column(Integer, primary_key=True)
+    message = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
 def init_db():
     Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:

--- a/backend/templates/admin_dashboard.html
+++ b/backend/templates/admin_dashboard.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Dashboard</title>
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <p><strong>Total Earnings:</strong> ${{ '%.2f' % total_earnings }}</p>
+  <p><strong>Total Merchants:</strong> {{ merchants }}</p>
+  <h2>Plan Distribution</h2>
+  <ul>
+  {% for name, count in breakdown.items() %}
+    <li>{{ name }}: {{ count }}</li>
+  {% endfor %}
+  </ul>
+  <h2>Send Broadcast</h2>
+  <form action="/admin/broadcast" method="post">
+    <textarea name="message" rows="3" cols="40" required></textarea><br>
+    <button type="submit">Send</button>
+  </form>
+  <h2>Recent Broadcasts</h2>
+  <ul>
+  {% for b in broadcasts %}
+    <li>{{ b.created_at.strftime('%Y-%m-%d %H:%M') }} - {{ b.message }}</li>
+  {% endfor %}
+  </ul>
+  <p><a href="/admin/logout">Logout</a></p>
+</body>
+</html>

--- a/backend/templates/admin_login.html
+++ b/backend/templates/admin_login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Login</title>
+</head>
+<body>
+  <h1>Admin Login</h1>
+  {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+  <form method="post">
+    <label>Password <input type="password" name="password" required></label>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Broadcast` model and initialize new table
- revamp admin auth flow with new session flag
- create admin login and dashboard templates
- implement broadcast storage and retrieval routes
- show statistics and recent broadcasts in admin dashboard

## Testing
- `python -m py_compile backend/models.py backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68809907efd48332b4b010b89a9d78eb