### PR TITLE
Update auth flows and navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,14 +6,22 @@ import Login from './Login';
 import Signup from './Signup';
 import Navbar from './Navbar';
 import RequireAuth from './RequireAuth';
+import RedirectIfAuthed from './RedirectIfAuthed';
+import Setup from './Setup';
 
-// For easier debugging, install React DevTools: https://reactjs.org/link/react-devtools
 export default function App() {
   return (
     <HashRouter>
       <Navbar />
       <Routes>
-        <Route path="/login" element={<Login />} />
+        <Route
+          path="/login"
+          element={
+            <RedirectIfAuthed>
+              <Login />
+            </RedirectIfAuthed>
+          }
+        />
         <Route path="/signup" element={<Signup />} />
         <Route
           path="/chat"
@@ -31,8 +39,23 @@ export default function App() {
             </RequireAuth>
           }
         />
-        <Route path="/" element={<Navigate to="/login" replace />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
+        <Route
+          path="/setup"
+          element={
+            <RequireAuth>
+              <Setup />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <RedirectIfAuthed>
+              <Login />
+            </RedirectIfAuthed>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </HashRouter>
   );

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 const API_BASE = import.meta.env.VITE_API_BASE;
 
@@ -33,6 +34,12 @@ export default function Login() {
         <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
         <button type="submit" className="bg-indigo-500 text-white px-4 py-2 rounded w-full">Login</button>
       </form>
+      <div className="text-sm mt-2">
+        <Link to="/signup" className="text-indigo-600">New here? Sign up instead</Link>
+      </div>
+      <div className="text-sm mt-1">
+        <span className="text-indigo-600 cursor-pointer">Forgot password?</span>
+      </div>
     </div>
   );
 }

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -11,10 +11,19 @@ export default function Navbar() {
       .catch(() => setLoggedIn(false));
   }, []);
 
+  const logout = async () => {
+    await fetch(`${import.meta.env.VITE_API_BASE}/logout`, {
+      method: 'POST',
+      credentials: 'include'
+    });
+    setLoggedIn(false);
+    window.location.href = '/';
+  };
+
   return (
     <nav className="navbar">
       <div className="nav-links">
-        {loggedIn && (
+        {loggedIn ? (
           <>
             <NavLink
               to="/chat"
@@ -30,19 +39,39 @@ export default function Navbar() {
                 isActive ? 'nav-link active' : 'nav-link'
               }
             >
-              Merchant Dashboard
+              Dashboard
+            </NavLink>
+            <span onClick={logout} className="nav-link" style={{ cursor: 'pointer' }}>
+              Logout
+            </span>
+          </>
+        ) : (
+          <>
+            <NavLink
+              to="/"
+              className={({ isActive }) =>
+                isActive ? 'nav-link active' : 'nav-link'
+              }
+            >
+              Home
+            </NavLink>
+            <NavLink
+              to="/login"
+              className={({ isActive }) =>
+                isActive ? 'nav-link active' : 'nav-link'
+              }
+            >
+              Login
+            </NavLink>
+            <NavLink
+              to="/signup"
+              className={({ isActive }) =>
+                isActive ? 'nav-link active' : 'nav-link'
+              }
+            >
+              Sign Up
             </NavLink>
           </>
-        )}
-        {!loggedIn && (
-          <NavLink
-            to="/login"
-            className={({ isActive }) =>
-              isActive ? 'nav-link active' : 'nav-link'
-            }
-          >
-            Login
-          </NavLink>
         )}
       </div>
     </nav>

--- a/frontend/src/RedirectIfAuthed.jsx
+++ b/frontend/src/RedirectIfAuthed.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+
+const API_BASE = import.meta.env.VITE_API_BASE;
+
+export default function RedirectIfAuthed({ children }) {
+  const [loading, setLoading] = useState(true);
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/me`, { credentials: 'include' })
+      .then(res => setAuthed(res.ok))
+      .catch(() => setAuthed(false))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return null;
+  if (authed) return <Navigate to="/chat" replace />;
+  return children;
+}

--- a/frontend/src/Setup.jsx
+++ b/frontend/src/Setup.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SetupModal from './SetupModal';
+
+export default function Setup() {
+  const close = () => {
+    window.location.href = '/dashboard';
+  };
+
+  return <SetupModal onClose={close} />;
+}

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -5,20 +5,24 @@ const API_BASE = import.meta.env.VITE_API_BASE;
 export default function Signup() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
   const [error, setError] = useState('');
-  const [plan, setPlan] = useState('start');
 
   const submit = async (e) => {
     e.preventDefault();
     setError('');
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
     const res = await fetch(`${API_BASE}/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ email, password, plan })
+      body: JSON.stringify({ email, password })
     });
     if (res.ok) {
-      window.location.href = '/dashboard';
+      window.location.href = '/setup';
     } else {
       const data = await res.json();
       setError(data.error || 'Signup failed');
@@ -32,11 +36,7 @@ export default function Signup() {
       <form onSubmit={submit} className="space-y-2">
         <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
         <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
-        <select className="border p-2 w-full" value={plan} onChange={e => setPlan(e.target.value)}>
-          <option value="start">Start</option>
-          <option value="grow">Grow</option>
-          <option value="pro">Pro</option>
-        </select>
+        <input className="border p-2 w-full" type="password" placeholder="Confirm Password" value={confirm} onChange={e => setConfirm(e.target.value)} />
         <button type="submit" className="bg-indigo-500 text-white px-4 py-2 rounded w-full">Create Account</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- improve login page UX links
- simplify signup page and redirect to setup modal
- add redirect logic for authenticated users
- expand navbar options and logout
- create setup route and auth redirect helper

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a9a926448332a97a7836c7ac9c98