### PR TITLE
Fix API base and add fetch error handling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,7 @@ import Setup from './Setup';
 
 export default function App() {
   return (
-    <HashRouter>
+    <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Navbar />
       <Routes>
         <Route

--- a/frontend/src/ChatApp.jsx
+++ b/frontend/src/ChatApp.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import Settings from './Settings';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import Settings, { API_BASE } from './Settings';
 
 function Message({ sender, text, time }) {
   return (
@@ -25,15 +23,20 @@ export default function ChatApp() {
   }, [messages, loading]);
 
   useEffect(() => {
-    fetch(`${API_BASE}/bot/${botName}`, { credentials: 'include' })
-      .then(res => res.json())
-      .then(data => {
+    const loadWelcome = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/bot/${botName}`, { credentials: 'include' });
+        const data = await res.json();
         if (data.suggestion) {
           setMessages([{ sender: 'bot', text: data.suggestion, time: new Date().toLocaleTimeString() }]);
         } else if (data.welcomeMessage) {
           setMessages([{ sender: 'bot', text: data.welcomeMessage, time: new Date().toLocaleTimeString() }]);
         }
-      });
+      } catch (err) {
+        console.error('Load welcome error:', err);
+      }
+    };
+    loadWelcome();
   }, [botName]);
 
   const sendMessage = async () => {
@@ -75,6 +78,7 @@ export default function ChatApp() {
         });
       }
     } catch (err) {
+      console.error('Chat error:', err);
       setMessages(prev => [...prev.slice(0, -1), { sender: 'bot', text: 'Bot is unavailable. Check server/API key.', time: botPlaceholder.time }]);
     } finally {
       setLoading(false);

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import { API_BASE } from './Settings';
 
 export default function Dashboard() {
   const [merchantId, setMerchantId] = useState(null);
@@ -76,6 +75,7 @@ export default function Dashboard() {
       setProductSettings(productSettingsData);
       setBotSettings(botSettingsData);
     } catch (err) {
+      console.error('Dashboard fetch error:', err);
       setError('Failed to fetch data');
       setAlert('Failed to fetch data');
     } finally {
@@ -144,6 +144,7 @@ export default function Dashboard() {
         setProductInfo(JSON.parse(text));
       }
     } catch (err) {
+      console.error('Fetch products error:', err);
       setSyncError('Failed to fetch products');
     }
   };
@@ -156,6 +157,7 @@ export default function Dashboard() {
       if (!res.ok) throw new Error('sync');
       await fetchProductList();
     } catch (err) {
+      console.error('Sync products error:', err);
       setSyncError('Failed to sync products');
     } finally {
       setSyncing(false);
@@ -163,23 +165,33 @@ export default function Dashboard() {
   };
 
   const saveProductSettings = async () => {
-    await fetch(`${API_BASE}/merchant/product-settings/${merchantId}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(productSettings)
-    });
-    fetchData();
-    setAlert('Settings saved');
+    try {
+      await fetch(`${API_BASE}/merchant/product-settings/${merchantId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(productSettings)
+      });
+      fetchData();
+      setAlert('Settings saved');
+    } catch (err) {
+      console.error('Save product settings error:', err);
+      setAlert('Failed to save settings');
+    }
   };
 
   const saveBotSettings = async () => {
-    await fetch(`${API_BASE}/merchant/bot-settings`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(botSettings)
-    });
-    fetchData();
-    setAlert('Settings saved');
+    try {
+      await fetch(`${API_BASE}/merchant/bot-settings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(botSettings)
+      });
+      fetchData();
+      setAlert('Settings saved');
+    } catch (err) {
+      console.error('Save bot settings error:', err);
+      setAlert('Failed to save settings');
+    }
   };
 
   const botOnline = logs.length && (Date.now() - new Date(logs[0].timestamp)) < 5 * 60 * 1000;

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import { API_BASE } from './Settings';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -11,17 +10,22 @@ export default function Login() {
   const submit = async (e) => {
     e.preventDefault();
     setError('');
-    const res = await fetch(`${API_BASE}/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ email, password })
-    });
-    if (res.ok) {
-      window.location.href = '/dashboard';
-    } else {
-      const data = await res.json();
-      setError(data.error || 'Login failed');
+    try {
+      const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password })
+      });
+      if (res.ok) {
+        window.location.href = '/dashboard';
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Login failed');
+      }
+    } catch (err) {
+      console.error('Login error:', err);
+      setError('Login failed');
     }
   };
 

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import './styles.css';
+import { API_BASE } from './Settings';
 
 export default function Navbar() {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -8,8 +9,9 @@ export default function Navbar() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_BASE}/me`, { credentials: 'include' })
-      .then(async res => {
+    const check = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/me`, { credentials: 'include' });
         if (res.ok) {
           const data = await res.json();
           setProfile(data);
@@ -17,25 +19,39 @@ export default function Navbar() {
         } else {
           setLoggedIn(false);
         }
-      })
-      .catch(() => setLoggedIn(false));
+      } catch (err) {
+        console.error('Navbar me error:', err);
+        setLoggedIn(false);
+      }
+    };
+    check();
   }, []);
 
   useEffect(() => {
     if (!loggedIn) return;
-    fetch(`${import.meta.env.VITE_API_BASE}/merchant/subscription`, { credentials: 'include' })
-      .then(res => res.json())
-      .then(data => setProfile(p => ({ ...p, subscription: data })))
-      .catch(() => {});
+    const load = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/merchant/subscription`, { credentials: 'include' });
+        const data = await res.json();
+        setProfile(p => ({ ...p, subscription: data }));
+      } catch (err) {
+        console.error('Subscription fetch error:', err);
+      }
+    };
+    load();
   }, [loggedIn]);
 
   const logout = async () => {
-    await fetch(`${import.meta.env.VITE_API_BASE}/logout`, {
-      method: 'POST',
-      credentials: 'include'
-    });
-    setLoggedIn(false);
-    window.location.href = '/';
+    try {
+      await fetch(`${API_BASE}/logout`, {
+        method: 'POST',
+        credentials: 'include'
+      });
+      setLoggedIn(false);
+      window.location.href = '/';
+    } catch (err) {
+      console.error('Logout error:', err);
+    }
   };
 
   return (

--- a/frontend/src/RedirectIfAuthed.jsx
+++ b/frontend/src/RedirectIfAuthed.jsx
@@ -1,17 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import { API_BASE } from './Settings';
 
 export default function RedirectIfAuthed({ children }) {
   const [loading, setLoading] = useState(true);
   const [authed, setAuthed] = useState(false);
 
   useEffect(() => {
-    fetch(`${API_BASE}/me`, { credentials: 'include' })
-      .then(res => setAuthed(res.ok))
-      .catch(() => setAuthed(false))
-      .finally(() => setLoading(false));
+    const check = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/me`, { credentials: 'include' });
+        setAuthed(res.ok);
+      } catch (err) {
+        console.error('Auth check error:', err);
+        setAuthed(false);
+      } finally {
+        setLoading(false);
+      }
+    };
+    check();
   }, []);
 
   if (loading) return null;

--- a/frontend/src/RequireAuth.jsx
+++ b/frontend/src/RequireAuth.jsx
@@ -1,18 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import { API_BASE } from './Settings';
 
 export default function RequireAuth({ children }) {
   const [loading, setLoading] = useState(true);
   const [authed, setAuthed] = useState(false);
 
   useEffect(() => {
-    fetch(`${API_BASE}/me`, { credentials: 'include' })
-      .then(res => {
+    const check = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/me`, { credentials: 'include' });
         if (res.ok) setAuthed(true);
-      })
-      .finally(() => setLoading(false));
+      } catch (err) {
+        console.error('Auth required check error:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    check();
   }, []);
 
   if (loading) return null;

--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -1,25 +1,35 @@
 import React, { useState, useEffect } from 'react';
 
-const API_BASE = import.meta.env.VITE_API_BASE;
+export const API_BASE = import.meta.env.VITE_API_BASE;
 
 export default function Settings({ onClose }) {
   const botName = 'Seep';
   const [welcome, setWelcome] = useState('');
 
   useEffect(() => {
-    fetch(`${API_BASE}/bot/${botName}`, { credentials: 'include' })
-      .then(res => res.json())
-      .then(data => setWelcome(data.welcomeMessage || ''));
+    (async () => {
+      try {
+        const res = await fetch(`${API_BASE}/bot/${botName}`, { credentials: 'include' });
+        const data = await res.json();
+        setWelcome(data.welcomeMessage || '');
+      } catch (err) {
+        console.error('Load settings error:', err);
+      }
+    })();
   }, []);
 
   const save = async () => {
-    await fetch(`${API_BASE}/bot/${botName}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ welcomeMessage: welcome })
-    });
-    onClose();
+    try {
+      await fetch(`${API_BASE}/bot/${botName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ welcomeMessage: welcome })
+      });
+      onClose();
+    } catch (err) {
+      console.error('Save settings error:', err);
+    }
   };
 
   return (

--- a/frontend/src/SetupModal.jsx
+++ b/frontend/src/SetupModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import { API_BASE } from './Settings';
 
 export default function SetupModal({ onClose }) {
   const [welcome, setWelcome] = useState('');
@@ -12,13 +11,17 @@ export default function SetupModal({ onClose }) {
   }, []);
 
   const save = async () => {
-    await fetch(`${API_BASE}/config`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ welcomeMessage: welcome, businessName: business })
-    });
-    localStorage.setItem('configSet', 'true');
-    onClose();
+    try {
+      await fetch(`${API_BASE}/config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ welcomeMessage: welcome, businessName: business })
+      });
+      localStorage.setItem('configSet', 'true');
+      onClose();
+    } catch (err) {
+      console.error('Setup save error:', err);
+    }
   };
 
   return (

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-
-const API_BASE = import.meta.env.VITE_API_BASE;
+import { API_BASE } from './Settings';
 
 export default function Signup() {
   const [email, setEmail] = useState('');
@@ -15,17 +14,22 @@ export default function Signup() {
       setError('Passwords do not match');
       return;
     }
-    const res = await fetch(`${API_BASE}/signup`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ email, password })
-    });
-    if (res.ok) {
-      window.location.href = '/setup';
-    } else {
-      const data = await res.json();
-      setError(data.error || 'Signup failed');
+    try {
+      const res = await fetch(`${API_BASE}/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password })
+      });
+      if (res.ok) {
+        window.location.href = '/setup';
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Signup failed');
+      }
+    } catch (err) {
+      console.error('Signup error:', err);
+      setError('Signup failed');
     }
   };
 


### PR DESCRIPTION
## Summary
- read API base from `.env` via `Settings.jsx` and export `API_BASE`
- use `API_BASE` and wrap frontend `fetch` calls with `try/catch`
- add React Router future flags to `<HashRouter>`
- keep `.env` ignored

Remember to restart the Vite dev server (`npm run dev`) so that `VITE_API_BASE` is reloaded.

## Testing
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688120ef34cc8332bcf1e9e648e5a125