### PR TITLE
Refine authentication flow and enforce plan selection

### DIFF
--- a/backend/templates/landing.html
+++ b/backend/templates/landing.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>SEEP Global</title>
+<nav>
+  <a href="/">Home</a> |
+  <a href="/login">Login</a> |
+  <a href="/signup">Sign Up</a>
+</nav>
+<h1>Welcome to SEEP Global</h1>
+<p>AI chatbot assistant for your store.</p>

--- a/backend/templates/select_plan.html
+++ b/backend/templates/select_plan.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Select Plan</title>
+<h1>Choose Your Plan</h1>
+<ul>
+  <li><button onclick="choosePlan('start')">Starter - 7 day trial</button></li>
+  <li><button onclick="choosePlan('growth')">Growth - 7 day trial</button></li>
+  <li><button onclick="choosePlan('elite')">Elite - 7 day trial</button></li>
+</ul>
+<script>
+function choosePlan(plan){
+  fetch('/billing/checkout',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({plan:plan, successUrl:'/merchant/dashboard', cancelUrl:'/select-plan'})
+  }).then(r=>r.json()).then(data=>{
+    if(data.url){ window.location = data.url; }
+    else if(data.error){ alert(data.error); }
+  });
+}
+</script>

--- a/backend/templates/signup.html
+++ b/backend/templates/signup.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>Sign Up</title>
+<h1>Create an Account</h1>
+<form method="post" action="/signup">
+  {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+  <label>Email: <input type="email" name="email" required></label><br>
+  <label>Password: <input type="password" name="password" required></label><br>
+  <label>Confirm Password: <input type="password" name="confirm" required></label><br>
+  <button type="submit">Sign Up</button>
+</form>
+<p><a href="/login">Already have an account? Log in</a></p>


### PR DESCRIPTION
## Summary
- Add public landing page and separate signup template
- Require password confirmation and prevent automatic login on signup
- Redirect new users without subscriptions to a plan-selection screen

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689448d684788332aae65f4672408819