### PR TITLE
feat: add discount codes and profile management

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -101,6 +101,25 @@ class Payment(Base):
     status = Column(String)
 
 
+class DiscountCode(Base):
+    """Admin generated token discounts."""
+    __tablename__ = 'discount_codes'
+    id = Column(Integer, primary_key=True)
+    code = Column(String, unique=True, nullable=False)
+    tokens = Column(Integer, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class MerchantCredit(Base):
+    """Additional token credits granted to merchants via discount codes."""
+    __tablename__ = 'merchant_credits'
+    id = Column(Integer, primary_key=True)
+    merchant_id = Column(String, ForeignKey('merchants.id'))
+    tokens = Column(Integer, nullable=False)
+    used_tokens = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
 class Product(Base):
 
     __tablename__ = "merchant_products"
@@ -172,9 +191,9 @@ def init_db():
     with SessionLocal() as db:
         if not db.query(Plan).count():
             db.add_all([
-                Plan(name='start', price_cents=1499, token_limit=150000),
-                Plan(name='growth', price_cents=2500, token_limit=300000),
-                Plan(name='elite', price_cents=4999, token_limit=1000000),
+                Plan(name='start', price_cents=1499, token_limit=15000),
+                Plan(name='growth', price_cents=2500, token_limit=50000),
+                Plan(name='elite', price_cents=4999, token_limit=-1),
             ])
             db.commit()
 

--- a/backend/templates/admin_dashboard.html
+++ b/backend/templates/admin_dashboard.html
@@ -20,6 +20,18 @@
     <textarea name="message" rows="3" cols="40" required></textarea><br>
     <button type="submit">Send</button>
   </form>
+  <h2>Create Discount Code</h2>
+  <form action="/admin/discount" method="post">
+    <input name="code" placeholder="CODE" required />
+    <input name="value" type="number" placeholder="Value ($)" required />
+    <button type="submit">Create</button>
+  </form>
+  <h2>Discount Codes</h2>
+  <ul>
+  {% for d in discounts %}
+    <li>{{ d.code }} - {{ d.tokens }} tokens</li>
+  {% endfor %}
+  </ul>
   <h2>Recent Broadcasts</h2>
   <ul>
   {% for b in broadcasts %}

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -32,7 +32,7 @@ export default function Login() {
   };
 
   return (
-    <div className="p-4 max-w-sm mx-auto">
+    <div className="p-6 max-w-sm mx-auto bg-white/80 backdrop-blur-md rounded shadow">
       <h1 className="text-xl font-semibold mb-4">Login</h1>
       {error && <p className="text-red-500 mb-2">{error}</p>}
       <form onSubmit={submit} className="space-y-2">

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -27,19 +27,14 @@ export default function Navbar() {
     check();
   }, []);
 
-  useEffect(() => {
-    if (!loggedIn) return;
-    const load = async () => {
-      try {
-        const res = await fetch(`${API_BASE}/merchant/usage`, { credentials: 'include' });
-        const usage = await res.json();
-        setProfile(p => ({ ...p, tokens: usage.tokens }));
-      } catch (err) {
-        console.error('Usage fetch error:', err);
-      }
-    };
-    load();
-  }, [loggedIn]);
+  const cancel = async () => {
+    try {
+      await fetch(`${API_BASE}/billing/cancel`, { method: 'POST', credentials: 'include' });
+      window.location.reload();
+    } catch (err) {
+      console.error('Cancel error:', err);
+    }
+  };
 
   const logout = async () => {
     try {
@@ -80,10 +75,11 @@ export default function Navbar() {
               {open && profile && (
                 <div className="profile-drop">
                   <p className="email">{profile.email}</p>
-                  {/* subscription details hidden */}
-                  {profile.tokens !== undefined && (
-                    <p className="tokens">Tokens Used: {profile.tokens}</p>
+                  {profile.plan && <p className="plan">Plan: {profile.plan}</p>}
+                  {profile.usage && (
+                    <p className="tokens">Tokens Used: {profile.usage.tokens}</p>
                   )}
+                  <button onClick={cancel}>Cancel Plan</button>
                   <button onClick={logout}>Logout</button>
                 </div>
               )}
@@ -91,14 +87,6 @@ export default function Navbar() {
           </>
         ) : (
           <>
-            <NavLink
-              to="/"
-              className={({ isActive }) =>
-                isActive ? 'nav-link active' : 'nav-link'
-              }
-            >
-              Home
-            </NavLink>
             <NavLink
               to="/login"
               className={({ isActive }) =>

--- a/frontend/src/SetupModal.jsx
+++ b/frontend/src/SetupModal.jsx
@@ -27,7 +27,8 @@ export default function SetupModal({ onClose }) {
   return (
     <div className="modal">
       <div className="modal-content">
-        <h2>Store Setup</h2>
+        <h2>Welcome to Seep Global</h2>
+        <p className="text-sm mb-2">Boost sales, recover carts, and keep customers informed with product-aware AI.</p>
         <label>
           Welcome message
           <input value={welcome} onChange={e => setWelcome(e.target.value)} />

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -36,7 +36,7 @@ export default function Signup() {
   };
 
   return (
-    <div className="p-4 max-w-sm mx-auto">
+    <div className="p-6 max-w-sm mx-auto bg-white/80 backdrop-blur-md rounded shadow">
       <h1 className="text-xl font-semibold mb-4">Sign Up</h1>
       {error && <p className="text-red-500 mb-2">{error}</p>}
       <form onSubmit={submit} className="space-y-2">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6,7 +6,7 @@ body {
   margin: 0;
   font-family: 'Inter', sans-serif;
   line-height: 1.5;
-  background: #f9fafb;
+  background: linear-gradient(135deg, #e0e7ff, #f9fafb);
   display: flex;
   justify-content: center;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- enforce env-based configuration for all secrets
- add discount code and credit models with admin management
- surface plan usage in /me, signup and profile UI with cancel support

## Testing
- `python -m py_compile backend/app.py backend/models.py`
- `npm --prefix frontend test` *(fails: Missing script "test")*
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68945678436c83328a57eddb4aba1b03